### PR TITLE
Fix panic when cloning pointers to string types.

### DIFF
--- a/masking.go
+++ b/masking.go
@@ -134,8 +134,9 @@ func (x *masking) clone(fieldName string, value reflect.Value, tag string) refle
 			}
 			tagValue := f.Tag.Get(filter.GetTagKey())
 			if fv.Type().Kind() == reflect.Ptr && fv.Elem().Kind() == reflect.String {
-				a := x.clone(f.Name, fv.Elem(), tagValue).Interface().(string)
-				dst.Elem().Field(i).Set(reflect.ValueOf(&a))
+				a := x.clone(f.Name, fv.Elem(), tagValue).Convert(reflect.TypeOf("")).Interface().(string)
+				dst.Elem().Field(i).Set(reflect.New(fv.Elem().Type()))
+				dst.Elem().Field(i).Elem().SetString(a)
 			} else {
 				dst.Elem().Field(i).Set(x.clone(f.Name, fv, tagValue))
 			}

--- a/masking_test.go
+++ b/masking_test.go
@@ -329,10 +329,12 @@ func TestVariousDatastructuresForVariousScenarios(t *testing.T) {
 }
 
 func TestAllFieldFilter(t *testing.T) {
+	type ID string
 	type child struct {
 		Data string
 	}
 	s := "test"
+	var id ID = "id"
 	type myStruct struct {
 		Func      func() time.Time
 		Chan      chan int
@@ -344,6 +346,10 @@ func TestAllFieldFilter(t *testing.T) {
 		Child     child
 		ChildPtr  *child
 		Data      string
+		Str       string
+		Pstr      *string
+		ID        ID
+		PID       *ID
 	}
 	data := &myStruct{
 		Func:      time.Now,
@@ -356,6 +362,10 @@ func TestAllFieldFilter(t *testing.T) {
 		Child:     child{Data: "x"},
 		ChildPtr:  &child{Data: "y"},
 		Data:      "data",
+		Str:       s,
+		Pstr:      &s,
+		ID:        id,
+		PID:       &id,
 	}
 
 	t.Run("default allfield filter", func(t *testing.T) {
@@ -377,6 +387,14 @@ func TestAllFieldFilter(t *testing.T) {
 		assert.Empty(t, copied.Child.Data)
 		assert.Empty(t, copied.ChildPtr.Data)
 		assert.Equal(t, filter.GetFilteredLabel(), copied.Data)
+		assert.Equal(t, ("test"), data.Str)
+		assert.Equal(t, filter.GetFilteredLabel(), copied.Str)
+		assert.Equal(t, ("test"), *data.Pstr)
+		assert.Equal(t, filter.GetFilteredLabel(), *copied.Pstr)
+		assert.Equal(t, ID("id"), data.ID)
+		assert.Equal(t, ID(filter.GetFilteredLabel()), copied.ID)
+		assert.Equal(t, ID("id"), *data.PID)
+		assert.Equal(t, ID(filter.GetFilteredLabel()), *copied.PID)
 	})
 
 	t.Run("custom allfield filter", func(t *testing.T) {
@@ -398,6 +416,14 @@ func TestAllFieldFilter(t *testing.T) {
 		assert.Empty(t, copied.Child.Data)
 		assert.Empty(t, copied.ChildPtr.Data)
 		assert.Equal(t, "************", copied.Data)
+		assert.Equal(t, ("test"), data.Str)
+		assert.Equal(t, "************", copied.Str)
+		assert.Equal(t, ("test"), *data.Pstr)
+		assert.Equal(t, "************", *copied.Pstr)
+		assert.Equal(t, ID("id"), data.ID)
+		assert.Equal(t, ID("************"), copied.ID)
+		assert.Equal(t, ID("id"), *data.PID)
+		assert.Equal(t, ID("************"), *copied.PID)
 	})
 
 }


### PR DESCRIPTION
The handling of pointers to string types can panic, if the type is something other than `*string`.
For example, a struct with a field of type `*ID`:
```
type ID string

type myStruct struct {
    Pid  *ID
}
```
will panic in this type assertion with the message `interface conversion: interface {} is main.ID, not string`:
```
	a := x.clone(f.Name, fv.Elem(), tagValue).Interface().(string)
```
To avoid this, use the reflect.Value method `Convert()` before the type assertion:
```
	a := x.clone(f.Name, fv.Elem(), tagValue).Convert(reflect.TypeOf("")).Interface().(string)
```
Then use reflect.New() to create a new reflect.Value of type `*ID`,  and use `SetString()` to modify the  value.

I have extended `TestAllFieldFilter` to verify this fix, including checks that the original struct is not modified.

