### PR TITLE
Fix of the array incorrect behaviour when cloning

### DIFF
--- a/masking.go
+++ b/masking.go
@@ -151,7 +151,11 @@ func (x *masking) clone(fieldName string, value reflect.Value, tag string) refle
 		}
 
 	case reflect.Array, reflect.Slice:
-		dst = reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+		if src.Kind() == reflect.Array {
+			dst = reflect.New(reflect.ArrayOf(src.Len(), src.Type().Elem())).Elem()
+		} else {
+			dst = reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+		}
 		for i := 0; i < src.Len(); i++ {
 			dst.Index(i).Set(x.clone(fieldName, src.Index(i), ""))
 		}

--- a/masking_test.go
+++ b/masking_test.go
@@ -578,6 +578,17 @@ func TestPiiPhoneNumber(t *testing.T) {
 
 }
 
+func TestCorrectBehaviourWithArray(t *testing.T) {
+	const issuedToken = "abcd1234"
+	maskTool := NewMaskTool(filter.ValueFilter(issuedToken))
+	arrayForTest := [1]string{issuedToken}
+	require.NotPanics(t, func() {
+		maskTool.MaskDetails(arrayForTest)
+	})
+	filteredData := maskTool.MaskDetails(arrayForTest)
+	assert.Equal(t, [1]string{"[filtered]"}, filteredData)
+}
+
 func TestCustomPiiPhoneNumber(t *testing.T) {
 	maskTool := NewMaskTool(filter.CustomPhoneFilter(customMasker.MMobile))
 


### PR DESCRIPTION
Hello Anuraag, this fix is closing the issue I raised over your masking tool, it fixes incorrect Array processing and package panicking when operating over the array (NOT SLICE).
Based solely on the same fix implemented in https://github.com/stretchr/testify/pull/1473/files 